### PR TITLE
Docker optimization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /code && mkdir -p /code/ipw
 RUN echo 'Etc/UTC' > /etc/timezone \
     && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime \
     && apt-get update -y \
-    && apt-get install -y gcc make man \
+    && apt-get install -y gcc make \
     && rm -rf /var/lib/apt/lists/*
 
 ####################################################
@@ -27,13 +27,16 @@ ENV IPW=/code/ipw
 # lets compile IPW
 COPY . / /code/ipw/
 
+# copy the compiled programs to /usr/local/bin as the
+# IPW environment variable will not be set most of the
+# time when the docker image is used with 'docker run'
 RUN cd /code/ipw \
     && cp bashrc /root/.bashrc \
     && /bin/bash -c "source /root/.bashrc" \
     && ./configure \
     && make \
     && make install \
-    # && cp /code/ipw/bin/* /usr/local/bin/ \
+    && cp /code/ipw/bin/* /usr/local/bin/ \
     && apt-get autoremove -y gcc make
     
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /code && mkdir -p /code/ipw
 RUN echo 'Etc/UTC' > /etc/timezone \
     && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime \
     && apt-get update -y \
-    && apt-get install -y gcc make \
+    && apt-get install -y libgomp1 gcc make \
     && rm -rf /var/lib/apt/lists/*
 
 ####################################################
@@ -38,7 +38,7 @@ RUN cd /code/ipw \
     && make install \
     && cp /code/ipw/bin/* /usr/local/bin/ \
     && apt-get autoremove -y gcc make
-    
+
 ENTRYPOINT ["/bin/bash"]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /code && mkdir -p /code/ipw
 RUN echo 'Etc/UTC' > /etc/timezone \
     && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime \
     && apt-get update -y \
-    && apt-get install -y build-essential man \
+    && apt-get install -y gcc make man \
     && rm -rf /var/lib/apt/lists/*
 
 ####################################################
@@ -33,7 +33,9 @@ RUN cd /code/ipw \
     && ./configure \
     && make \
     && make install \
-    && cp /code/ipw/bin/* /usr/local/bin/
+    && make clean \
+    # && cp /code/ipw/bin/* /usr/local/bin/ \
+    && apt-get autoremove -y gcc make
     
 ENTRYPOINT ["/bin/bash"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN cd /code/ipw \
     && ./configure \
     && make \
     && make install \
-    && make clean \
     # && cp /code/ipw/bin/* /usr/local/bin/ \
     && apt-get autoremove -y gcc make
     

--- a/bashrc
+++ b/bashrc
@@ -1,7 +1,7 @@
 # IPW path settings
 IPW=/code/ipw
 export IPW
-#PATH=`$IPW/path user`:$PATH
+PATH=`$IPW/path user`:$PATH
 MANPATH=`$IPW/path man`:$MANPATH
 
 # Since IPW used TMPDIR

--- a/bashrc
+++ b/bashrc
@@ -1,7 +1,7 @@
 # IPW path settings
 IPW=/code/ipw
 export IPW
-PATH=`$IPW/path user`:$PATH
+#PATH=`$IPW/path user`:$PATH
 MANPATH=`$IPW/path man`:$MANPATH
 
 # Since IPW used TMPDIR


### PR DESCRIPTION
The Ubuntu package `build-essential` added too many extra packages. IPW just needs `gcc` and `make` to install and these are now removed at the end. This helps to trim the image size from 348MB to 234MB.

**NOTE** merging this may have an effect on SMRF which use the `latest` tag of the docker image ([SMRF issue](https://github.com/USDA-ARS-NWRC/smrf/issues/110)).