### PR TITLE
Makefile - Remove dynamic file creation via perl.

### DIFF
--- a/src/bin/pixcalc/imath/Makefile
+++ b/src/bin/pixcalc/imath/Makefile
@@ -19,13 +19,7 @@ token.h : tokentypes.h
 
 token.o : tokentypes.c token.h
 
-tokentypes.c tokentypes.h : tokentypes.in
-	$(PERL) makeCode.pl tokentypes.h tokentypes.c < $^
-
 command.h : cmdcodes.h
 	touch $@
 
 command.o : cmdcodes.c
-
-cmdcodes.c cmdcodes.h : cmdcodes.in
-	$(PERL) makeCode.pl cmdcodes.h cmdcodes.c < $^


### PR DESCRIPTION
Just had a little surprise trying to compile this on our CHPC installation, where the perl version is different and does not create valid header and source files. Instead of trying to make the perl script work again, I decided to remove it since the dynamically created files are present and match the `.ini`. files.

Guess Danny was ahead of time, when introducing this early version of meta programming.